### PR TITLE
Two GETs on js submit

### DIFF
--- a/eamena/eamena/media/js/views/forms/component-condition-assessment.js
+++ b/eamena/eamena/media/js/views/forms/component-condition-assessment.js
@@ -121,8 +121,9 @@ define(['jquery',
                     formData.append('formdata', formValues);
                     console.log("Sending dropzone", formValues);
                 });
-                this.dropzoneInstance.on('complete', function(){
-                    location.reload();
+                this.dropzoneInstance.on('success', function(file, response){
+                    var data = JSON.parse(response);
+                    window.location.href = data.url;
                 });
             }
 

--- a/eamena/eamena/media/js/views/forms/file-upload.js
+++ b/eamena/eamena/media/js/views/forms/file-upload.js
@@ -60,8 +60,9 @@ define(['jquery',
                     var formValues = $('#formdata').val();
                     formData.append('formdata', formValues);
                 });
-                this.dropzoneInstance.on('complete', function(){
-                    location.reload();
+                this.dropzoneInstance.on('success', function(file, response){
+                    var data = JSON.parse(response);
+                    window.location.href = data.url;
                 });
             }
 

--- a/eamena/eamena/media/js/views/forms/related-files.js
+++ b/eamena/eamena/media/js/views/forms/related-files.js
@@ -98,8 +98,9 @@ define(['jquery',
                     var formValues = $('#formdata').val();
                     formData.append('formdata', formValues);
                 });
-                this.dropzoneInstance.on('complete', function(){
-                    location.reload();
+                this.dropzoneInstance.on('success', function(file, response){
+                    var data = JSON.parse(response);
+                    window.location.href = data.url;
                 });
             }
 


### PR DESCRIPTION
Dropdowns that access the resources view were being reloaded twice, once with the correct url after creating the resource, and then again to the original url on success. Now the correct url is passed back to the js and then loaded.

Must be merged alongside the eamena_dev PR.