### PR TITLE
Upload image reports

### DIFF
--- a/eamena/eamena/templates/resource-report.htm
+++ b/eamena/eamena/templates/resource-report.htm
@@ -21,7 +21,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% block css %}
     {{ block.super }}
     <link rel="stylesheet" href="{% static 'css/page_job_inner.css' %}">
-    <link rel="stylesheet" href="{% static 'css/reports.css' %}">
 {% endblock css%}
 {% block content %}
     {% include report_template %}

--- a/eamena/eamena/views/resources.py
+++ b/eamena/eamena/views/resources.py
@@ -17,6 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 '''
 
 import re
+import os
 import urllib,json
 from django.template import RequestContext
 from django.shortcuts import render_to_response
@@ -99,6 +100,9 @@ def report(request, resourceid):
                             report_info['subtype'] = 'Imagery'
         if 'FILE_PATH_E62' in report_info['source']['graph']:
             report_info['filepath'] = report_info['source']['graph']['FILE_PATH_E62'][0]
+            fileext = os.path.splitext(report_info['filepath']['FILE_PATH_E62__value'])[1]
+            if fileext == '.jpg' or fileext == '.png':
+                report_info['has_image'] = True
         if 'THUMBNAIL_E62' in report_info['source']['graph']:
             report_info['has_image'] = report_info['source']['graph']['THUMBNAIL_E62'][0]
         if 'URL_E51' in report_info['source']['graph']: #If the resource has a URL, it verifies that it is an APAAME json string, in which case it retrieves the url of the photo from the json string and passes it to the report


### PR DESCRIPTION
Fixes problem with bulk uploaded images not being shown in the Information Resource report. Due to the 'has_image' field only being true if there was a thumbnail image, which isn't created on bulk upload. Will now check that the file_path ends in .jpg or .png for image display.

Link for reports.css file is also removed.